### PR TITLE
Adding support for hardware type iLO

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -41,6 +41,9 @@ mainly, but not only, provisioning details.
       * `irmc://<host>:<port>`, where `<port>` is optional if using the default.
     * HUAWEI ibmc
       * `ibmc://<host>:<port>` (or `ibmc+http://<host>:<port>` to disable TLS)
+    * HPE ilo4
+      * `ilo4://<host>:<port>`, for ilo4 based systems and the port is optional,
+        if using the default one (443).
     * iLO 5 Redfish
       * `ilo5-redfish://` (or `ilo5-redfish+http://` to disable TLS), the hostname
         or IP address, and the path to the system ID are required,

--- a/pkg/bmc/access_test.go
+++ b/pkg/bmc/access_test.go
@@ -311,6 +311,36 @@ func TestParse(t *testing.T) {
 			Hostname: "192.168.122.1",
 			Path:     "",
 		},
+
+		{
+                        Scenario: "ilo4 url",
+                        Address:  "ilo4://192.168.122.1",
+                        Type:     "ilo4",
+                        Port:     "",
+                        Host:     "192.168.122.1",
+                        Hostname: "192.168.122.1",
+                        Path:     "",
+                },
+
+		{
+                        Scenario: "ilo4 url, ipv6",
+                        Address:  "ilo4://[fe80::fc33:62ff:fe83:8a76]",
+                        Type:     "ilo4",
+                        Port:     "",
+                        Host:     "fe80::fc33:62ff:fe83:8a76",
+                        Hostname: "[fe80::fc33:62ff:fe83:8a76]",
+                        Path:     "",
+                },
+
+                {
+                        Scenario: "ilo4 url, no sep",
+                        Address:  "ilo4:192.168.122.1",
+                        Type:     "ilo4",
+                        Port:     "",
+                        Host:     "192.168.122.1",
+                        Hostname: "192.168.122.1",
+                        Path:     "",
+                },
 	} {
 		t.Run(tc.Scenario, func(t *testing.T) {
 			url, err := getParsedURL(tc.Address)
@@ -546,6 +576,18 @@ func TestStaticDriverInfo(t *testing.T) {
 			management: "ibmc",
 			power:      "ibmc",
 			raid:       "no-raid",
+			vendor:     "",
+		},
+
+		{
+			Scenario:   "ilo4",
+			input:      "ilo4://192.168.122.1",
+			needsMac:   true,
+			driver:     "ilo",
+			boot:       "ilo-ipxe",
+			management: "",
+			power:      "",
+			raid:       "",
 			vendor:     "",
 		},
 	} {
@@ -879,6 +921,52 @@ func TestDriverInfo(t *testing.T) {
 				"ibmc_verify_ca": false,
 			},
 		},
+
+		{
+			Scenario: "ilo4",
+			input:    "ilo4://192.168.122.1",
+			expects: map[string]interface{}{
+				"ilo_address":   "192.168.122.1",
+				"ilo_password":  "",
+				"ilo_username":  "",
+				"ilo_verify_ca": false,
+			},
+		},
+
+		{
+                        Scenario: "ilo4 port",
+			input:    "ilo4://192.168.122.1:8080",
+                        expects: map[string]interface{}{
+                                "ilo_address":   "192.168.122.1",
+				"client_port":   "8080",
+                                "ilo_password":  "",
+                                "ilo_username":  "",
+                                "ilo_verify_ca": false,
+                        },
+                },
+
+		{
+			Scenario: "ilo4 ipv6",
+			input:    "ilo4://[fe80::fc33:62ff:fe83:8a76]",
+			expects: map[string]interface{}{
+				"ilo_address":   "fe80::fc33:62ff:fe83:8a76",
+				"ilo_password":  "",
+				"ilo_username":  "",
+				"ilo_verify_ca": false,
+			},
+		},
+
+		{
+                        Scenario: "ilo4 ipv6 port",
+			input:    "ilo4://[fe80::fc33:62ff:fe83:8a76]:8080",
+                        expects: map[string]interface{}{
+                                "ilo_address":   "fe80::fc33:62ff:fe83:8a76",
+				"client_port":   "8080",
+                                "ilo_password":  "",
+                                "ilo_username":  "",
+                                "ilo_verify_ca": false,
+                        },
+                },
 	} {
 		t.Run(tc.Scenario, func(t *testing.T) {
 			acc, err := NewAccessDetails(tc.input, true)

--- a/pkg/bmc/ilo4.go
+++ b/pkg/bmc/ilo4.go
@@ -1,0 +1,88 @@
+package bmc
+
+import (
+	"net/url"
+)
+
+func init() {
+	registerFactory("ilo4", newILOAccessDetails, []string{})
+}
+
+func newILOAccessDetails(parsedURL *url.URL, disableCertificateVerification bool) (AccessDetails, error) {
+	return &iLOAccessDetails{
+		bmcType:                        parsedURL.Scheme,
+		portNum:                        parsedURL.Port(),
+		hostname:                       parsedURL.Hostname(),
+		disableCertificateVerification: disableCertificateVerification,
+	}, nil
+}
+
+type iLOAccessDetails struct {
+	bmcType                        string
+	portNum                        string
+	hostname                       string
+	disableCertificateVerification bool
+}
+
+func (a *iLOAccessDetails) Type() string {
+	return a.bmcType
+}
+
+// NeedsMAC returns true when the host is going to need a separate
+// port created rather than having it discovered.
+func (a *iLOAccessDetails) NeedsMAC() bool {
+	// For the inspection to work, we need a MAC address
+        // https://github.com/metal3-io/baremetal-operator/pull/284#discussion_r317579040
+        return true
+}
+
+func (a *iLOAccessDetails) Driver() string {
+	return "ilo"
+}
+
+func (a *iLOAccessDetails) DisableCertificateVerification() bool {
+        return a.disableCertificateVerification
+}
+
+// DriverInfo returns a data structure to pass as the DriverInfo
+// parameter when creating a node in Ironic. The structure is
+// pre-populated with the access information, and the caller is
+// expected to add any other information that might be needed (such as
+// the kernel and ramdisk locations).
+func (a *iLOAccessDetails) DriverInfo(bmcCreds Credentials) map[string]interface{} {
+	result := map[string]interface{}{
+		"ilo_username": bmcCreds.Username,
+		"ilo_password": bmcCreds.Password,
+		"ilo_address":  a.hostname,
+	}
+
+	if a.disableCertificateVerification {
+                result["ilo_verify_ca"] = false
+        }
+
+	if a.portNum != "" {
+                result["client_port"] = a.portNum
+        }
+
+	return result
+}
+
+func (a *iLOAccessDetails) BootInterface() string {
+	return "ilo-ipxe"
+}
+
+func (a *iLOAccessDetails) ManagementInterface() string {
+	return ""
+}
+
+func (a *iLOAccessDetails) PowerInterface() string {
+	return ""
+}
+
+func (a *iLOAccessDetails) RAIDInterface() string {
+	return ""
+}
+
+func (a *iLOAccessDetails) VendorInterface() string {
+	return ""
+}


### PR DESCRIPTION
This commit add support for iLO hardware type to
deploy ilo4 based systems using BMO.